### PR TITLE
Feature: Silent output

### DIFF
--- a/archive.tf
+++ b/archive.tf
@@ -19,7 +19,7 @@ resource "null_resource" "archive" {
   }
 
   provisioner "local-exec" {
-    command     = lookup(data.external.archive.result, "build_command")
+    command     = var.silent ? join(" ", lookup(data.external.archive.result, "build_command"), "&>/dev/null") : lookup(data.external.archive.result, "build_command")
     working_dir = path.module
   }
 }
@@ -33,7 +33,7 @@ data "external" "built" {
   program = ["python", "${path.module}/built.py"]
 
   query = {
-    build_command  = lookup(data.external.archive.result, "build_command")
+    build_command  = var.silent ? join(" ", lookup(data.external.archive.result, "build_command"), "&>/dev/null") : lookup(data.external.archive.result, "build_command")
     filename_old   = lookup(null_resource.archive.triggers, "filename")
     filename_new   = lookup(data.external.archive.result, "filename")
     module_relpath = path.module

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,11 @@ variable "source_path" {
   type        = string
 }
 
+variable "silent" {
+  description = "True if the output from the build should be silent"
+  type        = bool
+}
+
 # Optional variables specific to this module.
 
 variable "build_command" {


### PR DESCRIPTION
### Overview
Added an option to suppress the output of the build so that it doesn't clog up our terminal when we use `terraform apply`

### Proposed changes
- Added new `silent` boolean variable
  - if it is true, simply pipe the build output into `/dev/null`

### Checklist
- [x] Clear title such as "Feature: ..." or "Fix: ..." or other
- [x] Clear and descriptive overview explaining why this change is needed
- [x] List of changes proposed in this pull request (short bullet points)
- [x] List of related changes such as external diffs, related releases or other
- [x] Additional notes that would help the reviewers approve more quickly and with confidence
